### PR TITLE
Fix: #479 react-refresh scope pollution

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -5,6 +5,10 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
+<script>
+    window.$RefreshReg$ = () => {};
+    window.$RefreshSig$ = () => () => {};
+</script>
 <body>
     <div id="root"></div>
 </body>

--- a/package.json
+++ b/package.json
@@ -15,10 +15,11 @@
     ]
   },
   "scripts": {
-    "start": "pkill -9 node; yarn clean && NODE_ENV=production docker-compose up -d && yarn build && yarn workspace @mono/server start",
-    "dev": "pkill -9 node; yarn clean && rm -rf ./db-data && docker-compose up -d && NODE_ENV=development concurrently \"yarn workspace @mono/server start\" \"yarn workspace @mono/app dev\"",
-    "docker-reload": "docker-compose down --volumes && rm -rf ./db-data && docker-compose up -d",
-    "build": "NODE_ENV=production yarn workspace @mono/app build",
+    "start": "pkill -9 node; yarn clean && yarn docker-reload && yarn build && yarn workspace @mono/server start || yarn docker-clean",
+    "dev": "pkill -9 node; yarn clean && yarn docker-reload && NODE_ENV=development concurrently \"yarn workspace @mono/server start\" \"yarn workspace @mono/app dev\"",
+    "docker-clean": "docker-compose down --volumes && rm -rf ./db-data",
+    "docker-reload": "yarn docker-clean && docker-compose up -d",
+    "build": "NODE_ENV=production yarn workspace @mono/app build && yarn tsc --noEmit false",
     "swc:common": "yarn workspaces foreach -v run swc",
     "swc-watch:common": "yarn workspaces foreach -vp run swc-watch",
     "clean": "yarn workspaces foreach -v exec rm -rf dist build",


### PR DESCRIPTION
Fixes: #479 

Thanks to @TheNaman047 for bringing this to my attention. 

- You should now be able to serve the webpack bundle (`./app/build`) with any server (including `npx serve, npx http-server`)
- Note that the backend is still running on `ts-node`, and any logic for dockerizing etc. is currently not included in the template. 
- I added a `tsc --noEmit false` command to the `yarn build` script as an intermediate step.